### PR TITLE
Add Nyan Blaze (HP Chromebook 14 G3) to script

### DIFF
--- a/make-arch_drv.sh
+++ b/make-arch_drv.sh
@@ -515,7 +515,7 @@ essentials () {
       echo
       exit 1
     else
-      if [ "$(echo "$chr_codename" | grep 'daisy')" ] || [ "$(echo "$chr_codename" | grep 'snow')" ] || [ "$(echo "$chr_codename" | grep 'peach')" ]; then
+      if [ "$(echo "$chr_codename" | grep 'daisy')" ] || [ "$(echo "$chr_codename" | grep 'snow')" ] || [ "$(echo "$chr_codename" | grep 'peach')"  ] || [ "$(echo "$chr_codename" | grep 'nyan_blaze')"  ] ; then
         alarm_codename='armv7-chromebook'
         armhf='armv7'
       elif [ "$(echo "$chr_codename" | grep 'veyron')" ]; then


### PR DESCRIPTION
I was scratching my head at trying to figure out what was wrong with this script when running it on a relative's Chromebook, just to then find out that the reason it wasn't downloading anything _(it gave me an extremely tiny tar.gz download that had no "-armv7" extension and also nothing in the file itself)_ is because the codename for the hardware wasn't being taken into account.

This should in theory fix that issue.

However, I've had an issue where even doing this manually results in a strange black screen when booting from the USB, so it might be worth looking into if anything extra needs to be done.